### PR TITLE
pivot stock intermediate model fixed

### DIFF
--- a/models/intermediate/local_bike/int_local_bike_ds_stocks.sql
+++ b/models/intermediate/local_bike/int_local_bike_ds_stocks.sql
@@ -1,8 +1,7 @@
 SELECT
     stores.store_name,
-    pdt.product_name,
+    stocks.product_id,
     quantity
 FROM
-    {{source("local_bike_ds", "t_stocks")}} AS stocks
-    INNER JOIN {{source("local_bike_ds", "t_products")}} AS pdt ON pdt.product_id = stocks.product_id
-    INNER JOIN {{source("local_bike_ds", "t_stores")}} AS stores ON stores.store_id = stocks.store_id
+    {{ ref("stg_local_bike_ds_t_stocks") }} AS stocks
+    INNER JOIN {{ ref("stg_local_bike_ds_t_stores") }} AS stores ON stores.store_id = stocks.store_id

--- a/models/mart/local_bike/mrt_local_bike_ds_product_stores.sql
+++ b/models/mart/local_bike/mrt_local_bike_ds_product_stores.sql
@@ -1,11 +1,10 @@
 select
-    pdt.product_id,
+    stocks.product_id,
     pdt.brand_id,
     pdt.product_name,
     pdt.category_id,
     pdt.model_year,
     pdt.list_price,
-    pdt.partition_date,
     pdt.nb_product_stocked,
     {{
         dbt_utils.pivot(
@@ -15,13 +14,13 @@ select
         )
     }}
 from {{ ref("int_local_bike_ds_stocks") }} AS stocks
-INNER JOIN {{ ref("int_local_bike_ds_products")}} AS pdt ON pdt.product_name = stocks.product_name
+INNER JOIN {{ ref("int_local_bike_ds_products")}} AS pdt ON pdt.product_id = stocks.product_id
 group by 
-    pdt.product_id,
+    stocks.product_id,
     pdt.brand_id,
     pdt.product_name,
     pdt.category_id,
     pdt.model_year,
     pdt.list_price,
-    pdt.partition_date,
     pdt.nb_product_stocked
+


### PR DESCRIPTION
so the major issue was that dbs.utils.pivot try to compare the pivoted value to a string without any cast
in my case I tried to pivot store_id to have the quantity of a product per store however i've imported store_id as an INT
which in turn prevent the dbt pivot to work
what i had to do was to match the store_name from the store staging model with the store id in the stock intermediate model
that way i can pivot the stock intermediate model in my mart model product_stores