### PR TITLE
PR new mart stores with yearly sales figures

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -38,5 +38,9 @@ clean-targets:         # directories to be removed by `dbt clean`
 models:
   dbt_local_bike:
     # Applies to all files under models/example/
-    example:
+    staging:
+      +materialized: view
+    intermediate:
+      +materialized: view
+    mart:
       +materialized: table

--- a/macros/calcul_sum_order_discount.sql
+++ b/macros/calcul_sum_order_discount.sql
@@ -1,3 +1,3 @@
-{% macro calcul_sum_order(price, discount) %}
-    
+{% macro calcul_sum_order_discount(price, quantity, discount) %}
+    ({{ price }} * {{ quantity }} ) * discount 
 {% endmacro%}

--- a/models/intermediate/local_bike/int_local_bike_ds_orders.sql
+++ b/models/intermediate/local_bike/int_local_bike_ds_orders.sql
@@ -3,8 +3,8 @@ WITH total_per_orders AS (
         oitem.order_id,
         SUM(oitem.quantity) AS qty_per_order,
         COUNT(oitem.product_id) AS nb_distinct_product,
-        SUM(oitem.list_price * oitem.quantity) AS amount_without_discount,
-        SUM((oitem.list_price * oitem.quantity) * oitem.discount ) AS discount_amount
+        ROUND(SUM(oitem.list_price * oitem.quantity),2) AS amount_without_discount,
+        ROUND(SUM({{ calcul_sum_order_discount('oitem.list_price', 'oitem.quantity', 'oitem.discount') }}),2) AS discount_amount
     FROM {{ref("stg_local_bike_ds_t_order_items")}} AS oitem
     GROUP BY
         oitem.order_id
@@ -20,10 +20,10 @@ SELECT
     orders.store_id,
     orders.staff_id,
     total.nb_distinct_product,
+    total.qty_per_order,
     total.amount_without_discount,
     total.discount_amount,
-    total.qty_per_order,
-    (total.amount_without_discount - total.discount_amount) AS amount_with_discount
+    ROUND((total.amount_without_discount - total.discount_amount), 2) AS amount_with_discount
 FROM
     {{ref("stg_local_bike_ds_t_orders")}} AS orders
     INNER JOIN total_per_orders AS total ON total.order_id = orders.order_id

--- a/models/intermediate/local_bike/int_local_bike_ds_orders_store_yearly.sql
+++ b/models/intermediate/local_bike/int_local_bike_ds_orders_store_yearly.sql
@@ -1,0 +1,16 @@
+SELECT
+    orders.store_id AS order_store_id,
+    DATE_TRUNC(orders.order_date, YEAR) AS reporting_date,
+    ROUND(
+        SUM(
+            (oitem.list_price * oitem.quantity) 
+            - 
+            {{ calcul_sum_order_discount('oitem.list_price', 'oitem.quantity', 'oitem.discount') }}
+        )
+    ,2) AS total_amount_store,
+FROM
+    {{ ref("stg_local_bike_ds_t_orders") }} AS orders
+    INNER JOIN {{ref("stg_local_bike_ds_t_order_items")}} AS oitem ON oitem.order_id = orders.order_id
+GROUP BY
+    order_store_id,
+    reporting_date

--- a/models/mart/local_bike/docs.md
+++ b/models/mart/local_bike/docs.md
@@ -18,11 +18,16 @@ This model provides a report of order per month by seller and stores
 {% docs mrt_local_bike_ds_product_stores %}
 
 This model provides a list of products, the global quantity stored across all stores and for each stores
+the column after **nb_product_stocked** are the stores name which will update automatically if more store are added in t_stores
 
 {% enddocs %}
 
 {% docs mrt_local_bike_ds_stores_orders %}
 
 This model provides a report of stores and their sales figures per year
+- **nb_orders**: The total number of order for a specific store.
+- **total_qty_store**: The quantity of items sold by a specific store.
+- **total_amount_store**: The Sales revenue across all years for a store.
+- the columns following those are the sales revenu per years
 
 {% enddocs %}

--- a/models/mart/local_bike/mrt_local_bike_ds_stores_orders.sql
+++ b/models/mart/local_bike/mrt_local_bike_ds_stores_orders.sql
@@ -4,13 +4,27 @@ WITH total_order_per_store AS (
         COUNT(DISTINCT orders.order_id) AS nb_orders,
         SUM(orders.amount_with_discount) AS total_amount_store,
         SUM(orders.qty_per_order) AS total_qty_store
-        
     FROM
         {{ ref("int_local_bike_ds_orders") }} AS orders
-
     GROUP BY
         orders.store_id
-)
+),
+
+pivot_orders_store_yearly AS(
+    SELECT
+        order_store_id,
+        {{
+            dbt_utils.pivot(
+                "reporting_date",
+                dbt_utils.get_column_values(ref("int_local_bike_ds_orders_store_yearly"), "reporting_date"),
+                then_value="total_amount_store",
+            )
+        }}
+    FROM
+        {{ ref("int_local_bike_ds_orders_store_yearly") }} AS stores
+    GROUP BY
+        order_store_id
+    )
 
 SELECT
     stores.store_id,
@@ -23,9 +37,12 @@ SELECT
     stores.zip_code,
     stores.nb_customer_state,
     tot_ord_store.nb_orders,
-    tot_ord_store.total_amount_store,
-    tot_ord_store.total_qty_store
-
+    tot_ord_store.total_qty_store,
+    ROUND(tot_ord_store.total_amount_store, 2) AS total_amount_store,
+    sales_yearly.*
 FROM
     {{ ref("int_local_bike_ds_stores") }} AS stores
     LEFT JOIN total_order_per_store AS tot_ord_store ON tot_ord_store.store_id = stores.store_id
+    LEFT JOIN pivot_orders_store_yearly AS sales_yearly ON sales_yearly.order_store_id = stores.store_id
+
+


### PR DESCRIPTION
the new columns years on mart mrt_local_bike_ds_stores_orders.sql come from a new intermediate model int_local_bike_ds_orders_store_yearly.
this model is then pivoted in mart model
documentation has been updated accordingly

I took the opportunity to also update dbt_project on the models materialization